### PR TITLE
feat(LINGUIST-230): Add ping endpoint

### DIFF
--- a/src/main/java/app/linguistai/bmvp/controller/PingController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/PingController.java
@@ -1,0 +1,24 @@
+package app.linguistai.bmvp.controller;
+
+import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.exception.ExceptionLogger;
+import app.linguistai.bmvp.request.QUserProfile;
+import app.linguistai.bmvp.response.RUserProfile;
+import app.linguistai.bmvp.response.Response;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("ping")
+public class PingController {
+
+    @GetMapping
+    public ResponseEntity<Object> ping() {
+        return Response.create("Server is up", HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
Added ping endpoint to get the current up status of the server. I was using Swagger to ping if the server is up before. It was not a good use and created problems in the status dashboard. This should fix the problem.