### PR TITLE
feat(LINGUIST-269): Logged dates stats implementation

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/Parameter.java
+++ b/src/main/java/app/linguistai/bmvp/consts/Parameter.java
@@ -1,0 +1,5 @@
+package app.linguistai.bmvp.consts;
+
+public class Parameter {
+    public static final String ASCENDING_ORDER = "asc";
+}

--- a/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
@@ -1,0 +1,32 @@
+package app.linguistai.bmvp.controller.stats;
+
+import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.exception.ExceptionLogger;
+import app.linguistai.bmvp.response.Response;
+import app.linguistai.bmvp.response.stats.RUserLoggedDate;
+import app.linguistai.bmvp.service.stats.UserLoggedDateService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("stats")
+public class UserLoggedDateController {
+
+	private final UserLoggedDateService loggedDateService;
+
+	@GetMapping("/logged-date")
+	public ResponseEntity<Object> getLoggedDate(@RequestHeader(Header.USER_EMAIL) String email,
+	                                            @RequestParam(required = false, defaultValue = "desc") String sort,
+	                                            @RequestParam(required = false) Integer daysLimit) {
+		try {
+			RUserLoggedDate loggedDates = loggedDateService.getLoggedDates(email, sort, daysLimit);
+			return Response.create("Successfully fetched logged dates", HttpStatus.OK, loggedDates);
+		} catch (Exception e) {
+			return Response.create(ExceptionLogger.log(e), HttpStatus.BAD_REQUEST);
+		}
+	}
+
+}

--- a/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
@@ -14,17 +14,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("stats")
 public class UserLoggedDateController {
 
-	private final UserLoggedDateService loggedDateService;
+    private final UserLoggedDateService loggedDateService;
 
-	@GetMapping("/logged-date")
-	public ResponseEntity<Object> getLoggedDate(@RequestHeader(Header.USER_EMAIL) String email,
-	                                            @RequestParam(required = false, defaultValue = "desc") String sort,
-	                                            @RequestParam(required = false) Integer daysLimit) {
-		try {
-			RUserLoggedDate loggedDates = loggedDateService.getLoggedDates(email, sort, daysLimit);
-			return Response.create("Successfully fetched logged dates", HttpStatus.OK, loggedDates);
-		} catch (Exception e) {
-			return Response.create("Could not fetch logged dates", HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-	}
+    @GetMapping("/logged-date")
+    public ResponseEntity<Object> getLoggedDate(@RequestHeader(Header.USER_EMAIL) String email,
+                                                @RequestParam(required = false, defaultValue = "desc") String sort,
+                                                @RequestParam(required = false) Integer daysLimit) {
+        try {
+            RUserLoggedDate loggedDates = loggedDateService.getLoggedDates(email, sort, daysLimit);
+            return Response.create("Successfully fetched logged dates", HttpStatus.OK, loggedDates);
+        } catch (Exception e) {
+            return Response.create("Could not fetch logged dates", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/stats/UserLoggedDateController.java
@@ -1,7 +1,6 @@
 package app.linguistai.bmvp.controller.stats;
 
 import app.linguistai.bmvp.consts.Header;
-import app.linguistai.bmvp.exception.ExceptionLogger;
 import app.linguistai.bmvp.response.Response;
 import app.linguistai.bmvp.response.stats.RUserLoggedDate;
 import app.linguistai.bmvp.service.stats.UserLoggedDateService;
@@ -25,8 +24,7 @@ public class UserLoggedDateController {
 			RUserLoggedDate loggedDates = loggedDateService.getLoggedDates(email, sort, daysLimit);
 			return Response.create("Successfully fetched logged dates", HttpStatus.OK, loggedDates);
 		} catch (Exception e) {
-			return Response.create(ExceptionLogger.log(e), HttpStatus.BAD_REQUEST);
+			return Response.create("Could not fetch logged dates", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
-
 }

--- a/src/main/java/app/linguistai/bmvp/model/embedded/UserLoggedDateId.java
+++ b/src/main/java/app/linguistai/bmvp/model/embedded/UserLoggedDateId.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.model.embedded;
+
+import app.linguistai.bmvp.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+import java.sql.Date;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLoggedDateId implements Serializable {
+	private User user;
+	private Date loggedDate;
+}

--- a/src/main/java/app/linguistai/bmvp/model/embedded/UserLoggedDateId.java
+++ b/src/main/java/app/linguistai/bmvp/model/embedded/UserLoggedDateId.java
@@ -13,6 +13,6 @@ import java.sql.Date;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserLoggedDateId implements Serializable {
-	private User user;
-	private Date loggedDate;
+    private User user;
+    private Date loggedDate;
 }

--- a/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
@@ -1,0 +1,31 @@
+package app.linguistai.bmvp.model.stats;
+
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.embedded.UserLoggedDateId;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+
+@Data
+@Entity
+@Table(name = "user_logged_date")
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(UserLoggedDateId.class)
+public class UserLoggedDate {
+
+	@Id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
+	@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+	private User user;
+
+	@Id
+	@Column(name = "logged_date", nullable = false)
+	private Date loggedDate;
+}

--- a/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
@@ -2,13 +2,12 @@ package app.linguistai.bmvp.model.stats;
 
 import app.linguistai.bmvp.model.User;
 import app.linguistai.bmvp.model.embedded.UserLoggedDateId;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.sql.Date;
 
 @Data
@@ -18,14 +17,15 @@ import java.sql.Date;
 @AllArgsConstructor
 @IdClass(UserLoggedDateId.class)
 public class UserLoggedDate {
-
 	@Id
+	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
 	@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 	private User user;
 
 	@Id
+	@NotNull
 	@Column(name = "logged_date", nullable = false)
 	private Date loggedDate;
 }

--- a/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/model/stats/UserLoggedDate.java
@@ -17,15 +17,15 @@ import java.sql.Date;
 @AllArgsConstructor
 @IdClass(UserLoggedDateId.class)
 public class UserLoggedDate {
-	@Id
-	@NotNull
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
-	@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-	private User user;
+    @Id
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+    private User user;
 
-	@Id
-	@NotNull
-	@Column(name = "logged_date", nullable = false)
-	private Date loggedDate;
+    @Id
+    @NotNull
+    @Column(name = "logged_date", nullable = false)
+    private Date loggedDate;
 }

--- a/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
@@ -1,0 +1,25 @@
+package app.linguistai.bmvp.repository.stats;
+
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.stats.UserLoggedDate;
+import app.linguistai.bmvp.model.embedded.UserLoggedDateId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface IUserLoggedDateRepository extends JpaRepository<UserLoggedDate, UserLoggedDateId> {
+
+	Optional<UserLoggedDate> findByUserAndLoggedDate(User user, Date loggedDate);
+
+	Optional<List<UserLoggedDate>> findByUserEmailOrderByLoggedDateDesc(String email);
+
+	Optional<List<UserLoggedDate>> findByUserEmailOrderByLoggedDateAsc(String email);
+
+	Optional<List<UserLoggedDate>> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(String email, Date startDate);
+
+	Optional<List<UserLoggedDate>> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(String email, Date startDate);
+}

--- a/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
@@ -5,21 +5,15 @@ import app.linguistai.bmvp.model.stats.UserLoggedDate;
 import app.linguistai.bmvp.model.embedded.UserLoggedDateId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import java.sql.Date;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface IUserLoggedDateRepository extends JpaRepository<UserLoggedDate, UserLoggedDateId> {
-
 	Optional<UserLoggedDate> findByUserAndLoggedDate(User user, Date loggedDate);
-
-	Optional<List<UserLoggedDate>> findByUserEmailOrderByLoggedDateDesc(String email);
-
-	Optional<List<UserLoggedDate>> findByUserEmailOrderByLoggedDateAsc(String email);
-
-	Optional<List<UserLoggedDate>> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(String email, Date startDate);
-
-	Optional<List<UserLoggedDate>> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(String email, Date startDate);
+	List<UserLoggedDate> findByUserEmailOrderByLoggedDateDesc(String email);
+	List<UserLoggedDate> findByUserEmailOrderByLoggedDateAsc(String email);
+	List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(String email, Date startDate);
+	List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(String email, Date startDate);
 }

--- a/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/stats/IUserLoggedDateRepository.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 
 @Repository
 public interface IUserLoggedDateRepository extends JpaRepository<UserLoggedDate, UserLoggedDateId> {
-	Optional<UserLoggedDate> findByUserAndLoggedDate(User user, Date loggedDate);
-	List<UserLoggedDate> findByUserEmailOrderByLoggedDateDesc(String email);
-	List<UserLoggedDate> findByUserEmailOrderByLoggedDateAsc(String email);
-	List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(String email, Date startDate);
-	List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(String email, Date startDate);
+    Optional<UserLoggedDate> findByUserAndLoggedDate(User user, Date loggedDate);
+    List<UserLoggedDate> findByUserEmailOrderByLoggedDateDesc(String email);
+    List<UserLoggedDate> findByUserEmailOrderByLoggedDateAsc(String email);
+    List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(String email, Date startDate);
+    List<UserLoggedDate> findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(String email, Date startDate);
 }

--- a/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
@@ -1,0 +1,15 @@
+package app.linguistai.bmvp.response.stats;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Date;
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RUserLoggedDate {
+	private List<Date> loggedDates;
+}

--- a/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class RUserLoggedDate {
-	private List<Date> loggedDates;
+    private List<Date> loggedDates;
 }

--- a/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
+++ b/src/main/java/app/linguistai/bmvp/response/stats/RUserLoggedDate.java
@@ -3,7 +3,6 @@ package app.linguistai.bmvp.response.stats;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
 import java.sql.Date;
 import java.util.List;
 

--- a/src/main/java/app/linguistai/bmvp/service/AccountService.java
+++ b/src/main/java/app/linguistai/bmvp/service/AccountService.java
@@ -79,7 +79,7 @@ public class AccountService {
 
             return new RLoginUser(dbUser, accessToken, refreshToken);
         } catch (Exception e2) {
-            System.out.println("login exception");
+            System.out.println("Login exception");
             throw e2;
         }
     }
@@ -93,7 +93,7 @@ public class AccountService {
             return new RRefreshToken(accessToken);
 
         } catch (Exception e) {
-            System.out.println("refresh token exception");
+            System.out.println("Refresh token exception");
             throw e;
         }
     }
@@ -111,8 +111,8 @@ public class AccountService {
             boolean passwordMatch = bCryptPasswordEncoder.matches(passwords.getOldPassword(), hashedPassword);
 
             if (!passwordMatch) {
-                System.out.println("Passwords does not match");
-                throw new Exception("Passwords does not match");
+                System.out.println("Passwords do not match");
+                throw new Exception("Passwords do not match");
             }
 
             // hash new password
@@ -123,7 +123,7 @@ public class AccountService {
 
             return true;
         } catch (Exception e) {
-            System.out.println("password change exception exception");
+            System.out.println("Password change exception exception");
             throw e;
         }
     }

--- a/src/main/java/app/linguistai/bmvp/service/AccountService.java
+++ b/src/main/java/app/linguistai/bmvp/service/AccountService.java
@@ -8,6 +8,7 @@ import app.linguistai.bmvp.exception.ExceptionLogger;
 import app.linguistai.bmvp.exception.NotFoundException;
 import app.linguistai.bmvp.model.ResetToken;
 import app.linguistai.bmvp.repository.IResetTokenRepository;
+import app.linguistai.bmvp.service.stats.UserLoggedDateService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -42,6 +43,7 @@ public class AccountService {
     private final JWTUtils jwtUtils;
 
     private final UserStreakService userStreakService;
+    private final UserLoggedDateService userLoggedDateService;
 
     public RLoginUser login(QUserLogin user) throws Exception {
         try {
@@ -71,6 +73,9 @@ public class AccountService {
                 // Intentionally not thrown to not cause login exception for users without UserStreak
                 System.out.println(ExceptionLogger.log(e1));
             }
+
+            // Add the current date as a logged date
+            userLoggedDateService.addLoggedDateByEmailAndDate(dbUser.getEmail(), new Date());
 
             return new RLoginUser(dbUser, accessToken, refreshToken);
         } catch (Exception e2) {
@@ -106,8 +111,8 @@ public class AccountService {
             boolean passwordMatch = bCryptPasswordEncoder.matches(passwords.getOldPassword(), hashedPassword);
 
             if (!passwordMatch) {
-                System.out.println("passwords does not match");
-                throw new Exception("pasword no match");
+                System.out.println("Passwords does not match");
+                throw new Exception("Passwords does not match");
             }
 
             // hash new password
@@ -131,7 +136,7 @@ public class AccountService {
             if (userExist) {
                 throw new Exception("User already exists");
             } else {
-                // generate uuid and hash password if user does not exist in the system
+                // Generate uuid and hash password if user does not exist in the system
                 requestUser.setId(UUID.randomUUID());
                 requestUser.setPassword(encodePassword(requestUser.getPassword()));
 
@@ -142,7 +147,7 @@ public class AccountService {
                     throw new Exception("ERROR: Could not generate UserStreak for user with ID: [" + newUser.getId() + "]. Perhaps UserStreak already exists?");
                 }
 
-                // create access and resset tokens so that user does not have to login after registering
+                // Create access and reset tokens so that user does not have to log in after registering
                 final UserDetails userDetails = jwtUserService.loadUserByUsername(newUser.getEmail());
                 final String accessToken = jwtUtils.createAccessToken(userDetails);
                 final String refreshToken = jwtUtils.createRefreshToken(userDetails);

--- a/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
+++ b/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
@@ -1,0 +1,75 @@
+package app.linguistai.bmvp.service.stats;
+
+import app.linguistai.bmvp.exception.NotFoundException;
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.stats.UserLoggedDate;
+import app.linguistai.bmvp.repository.IAccountRepository;
+import app.linguistai.bmvp.repository.stats.IUserLoggedDateRepository;
+import app.linguistai.bmvp.response.stats.RUserLoggedDate;
+import app.linguistai.bmvp.utils.DateUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class UserLoggedDateService {
+
+	private final IUserLoggedDateRepository userLoggedDateRepository;
+	private final IAccountRepository accountRepository;
+
+	public RUserLoggedDate getLoggedDates(String email, String sort, Integer numDays) {
+		// Validate numDays
+		if (numDays != null && numDays < 0) {
+			throw new IllegalArgumentException("Number of days must be a non-negative integer");
+		}
+
+		// Calculate startDate if numDays is not null
+		Date startDate = null;
+		if (numDays != null) {
+			startDate = Date.valueOf(LocalDate.now().minusDays(numDays));
+		}
+
+		// Retrieve user logged dates based on sort order and startDate
+		Optional<List<UserLoggedDate>> optionalUserLoggedDates;
+		if ("asc".equalsIgnoreCase(sort)) {
+			optionalUserLoggedDates = (startDate != null) ?
+					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(email, startDate) :
+					userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(email);
+		} else { // Default is descending order
+			optionalUserLoggedDates = (startDate != null) ?
+					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(email, startDate) :
+					userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(email);
+		}
+
+		List<UserLoggedDate> loggedDates = optionalUserLoggedDates.orElse(Collections.emptyList());
+		List<Date> dateList = loggedDates.stream()
+				.map(UserLoggedDate::getLoggedDate)
+				.collect(Collectors.toList());
+
+		return RUserLoggedDate.builder()
+				.loggedDates(dateList)
+				.build();
+	}
+
+	@Transactional
+	public void addLoggedDateByEmailAndDate(String email, java.util.Date loggedDate) throws NotFoundException {
+		User user = accountRepository.findUserByEmail(email)
+				.orElseThrow(() -> new NotFoundException("User does not exist for given email: [" + email + "]."));
+
+		Optional<UserLoggedDate> existingLoggedDate = userLoggedDateRepository.findByUserAndLoggedDate(user,
+				DateUtils.convertUtilDateToSqlDate(loggedDate));
+
+		if (existingLoggedDate.isEmpty()) {
+			UserLoggedDate newUserLoggedDate = new UserLoggedDate(user, DateUtils.convertUtilDateToSqlDate(loggedDate));
+			userLoggedDateRepository.save(newUserLoggedDate);
+		}
+	}
+}

--- a/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
+++ b/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
@@ -20,54 +20,54 @@ import java.util.stream.Collectors;
 @Service
 public class UserLoggedDateService {
 
-	private final IUserLoggedDateRepository userLoggedDateRepository;
-	private final IAccountRepository accountRepository;
+    private final IUserLoggedDateRepository userLoggedDateRepository;
+    private final IAccountRepository accountRepository;
 
-	@Transactional
-	public RUserLoggedDate getLoggedDates(String email, String sort, Integer numDays) {
-		// Validate numDays
-		if (numDays != null && numDays < 0) {
-			throw new IllegalArgumentException("Number of days must be a non-negative integer");
-		}
+    @Transactional
+    public RUserLoggedDate getLoggedDates(String email, String sort, Integer numDays) {
+        // Validate numDays
+        if (numDays != null && numDays < 0) {
+            throw new IllegalArgumentException("Number of days must be a non-negative integer");
+        }
 
-		// Calculate startDate if numDays is not null
-		Date startDate = null;
-		if (numDays != null) {
-			startDate = Date.valueOf(LocalDate.now().minusDays(numDays));
-		}
+        // Calculate startDate if numDays is not null
+        Date startDate = null;
+        if (numDays != null) {
+            startDate = Date.valueOf(LocalDate.now().minusDays(numDays));
+        }
 
-		// Retrieve user logged dates based on sort order and startDate
-		List<UserLoggedDate> loggedDates;
-		if ("asc".equalsIgnoreCase(sort)) {
-			loggedDates = (startDate != null) ?
-					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(email, startDate) :
-					userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(email);
-		} else { // Default is descending order
-			loggedDates = (startDate != null) ?
-					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(email, startDate) :
-					userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(email);
-		}
+        // Retrieve user logged dates based on sort order and startDate
+        List<UserLoggedDate> loggedDates;
+        if ("asc".equalsIgnoreCase(sort)) {
+            loggedDates = (startDate != null) ?
+                    userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(email, startDate) :
+                    userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(email);
+        } else { // Default is descending order
+            loggedDates = (startDate != null) ?
+                    userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(email, startDate) :
+                    userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(email);
+        }
 
-		List<Date> dateList = loggedDates.stream()
-				.map(UserLoggedDate::getLoggedDate)
-				.collect(Collectors.toList());
+        List<Date> dateList = loggedDates.stream()
+                .map(UserLoggedDate::getLoggedDate)
+                .collect(Collectors.toList());
 
-		return RUserLoggedDate.builder()
-				.loggedDates(dateList)
-				.build();
-	}
+        return RUserLoggedDate.builder()
+                .loggedDates(dateList)
+                .build();
+    }
 
-	@Transactional
-	public void addLoggedDateByEmailAndDate(String email, java.util.Date loggedDate) throws NotFoundException {
-		User user = accountRepository.findUserByEmail(email)
-				.orElseThrow(() -> new NotFoundException("User does not exist for given email: [" + email + "]."));
+    @Transactional
+    public void addLoggedDateByEmailAndDate(String email, java.util.Date loggedDate) throws NotFoundException {
+        User user = accountRepository.findUserByEmail(email)
+                .orElseThrow(() -> new NotFoundException("User does not exist for given email: [" + email + "]."));
 
-		Optional<UserLoggedDate> existingLoggedDate = userLoggedDateRepository.findByUserAndLoggedDate(user,
-				DateUtils.convertUtilDateToSqlDate(loggedDate));
+        Optional<UserLoggedDate> existingLoggedDate = userLoggedDateRepository.findByUserAndLoggedDate(user,
+                DateUtils.convertUtilDateToSqlDate(loggedDate));
 
-		if (existingLoggedDate.isEmpty()) {
-			UserLoggedDate newUserLoggedDate = new UserLoggedDate(user, DateUtils.convertUtilDateToSqlDate(loggedDate));
-			userLoggedDateRepository.save(newUserLoggedDate);
-		}
-	}
+        if (existingLoggedDate.isEmpty()) {
+            UserLoggedDate newUserLoggedDate = new UserLoggedDate(user, DateUtils.convertUtilDateToSqlDate(loggedDate));
+            userLoggedDateRepository.save(newUserLoggedDate);
+        }
+    }
 }

--- a/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
+++ b/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
@@ -10,10 +10,8 @@ import app.linguistai.bmvp.utils.DateUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -25,6 +23,7 @@ public class UserLoggedDateService {
 	private final IUserLoggedDateRepository userLoggedDateRepository;
 	private final IAccountRepository accountRepository;
 
+	@Transactional
 	public RUserLoggedDate getLoggedDates(String email, String sort, Integer numDays) {
 		// Validate numDays
 		if (numDays != null && numDays < 0) {
@@ -38,18 +37,17 @@ public class UserLoggedDateService {
 		}
 
 		// Retrieve user logged dates based on sort order and startDate
-		Optional<List<UserLoggedDate>> optionalUserLoggedDates;
+		List<UserLoggedDate> loggedDates;
 		if ("asc".equalsIgnoreCase(sort)) {
-			optionalUserLoggedDates = (startDate != null) ?
+			loggedDates = (startDate != null) ?
 					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(email, startDate) :
 					userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(email);
 		} else { // Default is descending order
-			optionalUserLoggedDates = (startDate != null) ?
+			loggedDates = (startDate != null) ?
 					userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateDesc(email, startDate) :
 					userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(email);
 		}
 
-		List<UserLoggedDate> loggedDates = optionalUserLoggedDates.orElse(Collections.emptyList());
 		List<Date> dateList = loggedDates.stream()
 				.map(UserLoggedDate::getLoggedDate)
 				.collect(Collectors.toList());

--- a/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
+++ b/src/main/java/app/linguistai/bmvp/service/stats/UserLoggedDateService.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import app.linguistai.bmvp.consts.Parameter;
 
 @RequiredArgsConstructor
 @Service
@@ -38,7 +39,7 @@ public class UserLoggedDateService {
 
         // Retrieve user logged dates based on sort order and startDate
         List<UserLoggedDate> loggedDates;
-        if ("asc".equalsIgnoreCase(sort)) {
+        if (Parameter.ASCENDING_ORDER.equalsIgnoreCase(sort)) {
             loggedDates = (startDate != null) ?
                     userLoggedDateRepository.findByUserEmailAndLoggedDateGreaterThanEqualOrderByLoggedDateAsc(email, startDate) :
                     userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(email);

--- a/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
@@ -1,0 +1,157 @@
+package app.linguistai.bmvp.service.stats;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import app.linguistai.bmvp.exception.NotFoundException;
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.stats.UserLoggedDate;
+import app.linguistai.bmvp.repository.IAccountRepository;
+import app.linguistai.bmvp.repository.stats.IUserLoggedDateRepository;
+import app.linguistai.bmvp.response.stats.RUserLoggedDate;
+import app.linguistai.bmvp.utils.DateUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserLoggedDateServiceTest {
+
+	@Mock
+	private IUserLoggedDateRepository userLoggedDateRepository;
+
+	@Mock
+	private IAccountRepository accountRepository;
+
+	@InjectMocks
+	private UserLoggedDateService userLoggedDateService;
+
+	@DisplayName("When adding a new logged date for a valid user, verify it is saved")
+	@Test
+	void whenAddingNewLoggedDateThenVerifySaved() throws NotFoundException {
+		User user = new User();
+		user.setEmail("test@test.com");
+		user.setId(UUID.randomUUID());
+
+		java.util.Date loggedDate = new java.util.Date();
+
+		when(accountRepository.findUserByEmail(user.getEmail()))
+				.thenReturn(Optional.of(user));
+		when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), any()))
+				.thenReturn(Optional.empty());
+
+		userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
+
+		verify(userLoggedDateRepository, times(1)).findByUserAndLoggedDate(eq(user), any());
+		verify(userLoggedDateRepository, times(1)).save(any(UserLoggedDate.class));
+	}
+
+	@DisplayName("When user logs in on five different dates, check if all dates are returned")
+	@Test
+	void whenUserLogsInOnFiveDifferentDatesThenCheckIfAllDatesReturned() {
+		User user = new User();
+		user.setEmail("test@test.com");
+		user.setId(UUID.randomUUID());
+
+		Date date1 = Date.valueOf("2024-03-28");
+		Date date2 = Date.valueOf("2024-03-29");
+		Date date3 = Date.valueOf("2024-03-30");
+
+		List<UserLoggedDate> loggedDates = new ArrayList<>();
+		loggedDates.add(new UserLoggedDate(user, date1));
+		loggedDates.add(new UserLoggedDate(user, date2));
+		loggedDates.add(new UserLoggedDate(user, date3));
+
+		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail()))
+				.thenReturn(Optional.of(loggedDates));
+
+		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), "desc", null);
+
+		List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
+
+		assertEquals(loggedDates.size(), returnedDates.size());
+		assertTrue(returnedDates.contains(date1));
+		assertTrue(returnedDates.contains(date2));
+		assertTrue(returnedDates.contains(date3));
+	}
+
+	@DisplayName("When adding a logged date for an unregistered user, throw NotFoundException")
+	@Test
+	void whenAddingLoggedDateForUnregisteredUserThenThrowNotFoundException() {
+		String email = "unregistered@test.com";
+		java.util.Date loggedDate = new java.util.Date();
+
+		when(accountRepository.findUserByEmail(anyString()))
+				.thenReturn(Optional.empty());
+
+		assertThrows(NotFoundException.class, () -> {
+			userLoggedDateService.addLoggedDateByEmailAndDate(email, loggedDate);
+		});
+	}
+
+	@DisplayName("When adding a logged date for a user who logged in twice on the same day, do not add it again")
+	@Test
+	void whenAddingLoggedDateForUserWithDuplicateDateThenDoNotAddAgain() throws NotFoundException {
+		User user = new User();
+		user.setEmail("test@test.com");
+		user.setId(UUID.randomUUID());
+
+		java.util.Date loggedDate = Date.valueOf("2024-03-28");
+
+		when(accountRepository.findUserByEmail(user.getEmail()))
+				.thenReturn(Optional.of(user));
+		when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), eq(DateUtils.convertUtilDateToSqlDate(loggedDate))))
+				.thenReturn(java.util.Optional.of(new UserLoggedDate()));
+
+		userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
+
+		verify(userLoggedDateRepository, never()).save(any(UserLoggedDate.class));
+
+	}
+
+	@Test
+	@DisplayName("When fetching logged dates in ascending order, verify sorting")
+	void testGetLoggedDatesAscendingOrderWithNullDaysLimit() {
+		String sort = "asc";
+
+		User user = new User();
+		user.setEmail("test@test.com");
+		user.setId(UUID.randomUUID());
+
+		Date date1 = Date.valueOf("2024-03-28");
+		Date date2 = Date.valueOf("2024-03-29");
+		Date date3 = Date.valueOf("2024-03-30");
+
+		List<UserLoggedDate> loggedDates = new ArrayList<>();
+		loggedDates.add(new UserLoggedDate(user, date1));
+		loggedDates.add(new UserLoggedDate(user, date3));
+		loggedDates.add(new UserLoggedDate(user, date2));
+
+		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(user.getEmail()))
+				.thenReturn(Optional.of(loggedDates.stream()
+						.sorted(Comparator.comparing(UserLoggedDate::getLoggedDate))
+						.collect(Collectors.toList())));
+
+		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), sort, null);
+
+		List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
+
+		assertNotNull(returnedDates);
+		for (int i = 0; i < returnedDates.size() - 1; i++) {
+			assertTrue(returnedDates.get(i).before(returnedDates.get(i + 1)) || returnedDates.get(i).equals(returnedDates.get(i + 1)));
+		}
+		assertEquals(loggedDates.size(), returnedDates.size());
+	}
+
+}

--- a/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -74,7 +75,7 @@ public class UserLoggedDateServiceTest {
 		loggedDates.add(new UserLoggedDate(user, date3));
 
 		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail()))
-				.thenReturn(Optional.of(loggedDates));
+				.thenReturn(loggedDates);
 
 		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), "desc", null);
 
@@ -139,9 +140,9 @@ public class UserLoggedDateServiceTest {
 		loggedDates.add(new UserLoggedDate(user, date2));
 
 		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(user.getEmail()))
-				.thenReturn(Optional.of(loggedDates.stream()
+				.thenReturn(loggedDates.stream()
 						.sorted(Comparator.comparing(UserLoggedDate::getLoggedDate))
-						.collect(Collectors.toList())));
+						.collect(Collectors.toList()));
 
 		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), sort, null);
 
@@ -154,4 +155,17 @@ public class UserLoggedDateServiceTest {
 		assertEquals(loggedDates.size(), returnedDates.size());
 	}
 
+	@DisplayName("When getting logged dates for a user who never logged in, verify empty list is returned")
+	@Test
+	void whenGettingLoggedDatesForUserNeverLoggedInThenVerifyEmptyList() throws NotFoundException {
+		User user = new User();
+		user.setEmail("test@test.com");
+		user.setId(UUID.randomUUID());
+
+		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail())).thenReturn(Collections.emptyList());
+
+		RUserLoggedDate rUserLoggedDate = userLoggedDateService.getLoggedDates(user.getEmail(), null, null);
+
+		assertTrue(rUserLoggedDate.getLoggedDates().isEmpty());
+	}
 }

--- a/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
@@ -29,143 +29,143 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class UserLoggedDateServiceTest {
 
-	@Mock
-	private IUserLoggedDateRepository userLoggedDateRepository;
+    @Mock
+    private IUserLoggedDateRepository userLoggedDateRepository;
 
-	@Mock
-	private IAccountRepository accountRepository;
+    @Mock
+    private IAccountRepository accountRepository;
 
-	@InjectMocks
-	private UserLoggedDateService userLoggedDateService;
+    @InjectMocks
+    private UserLoggedDateService userLoggedDateService;
 
-	@DisplayName("When adding a new logged date for a valid user, verify it is saved")
-	@Test
-	void whenAddingNewLoggedDateThenVerifySaved() throws NotFoundException {
-		User user = new User();
-		user.setEmail("test@test.com");
-		user.setId(UUID.randomUUID());
+    @DisplayName("When adding a new logged date for a valid user, verify it is saved")
+    @Test
+    void whenAddingNewLoggedDateThenVerifySaved() throws NotFoundException {
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setId(UUID.randomUUID());
 
-		java.util.Date loggedDate = new java.util.Date();
+        java.util.Date loggedDate = new java.util.Date();
 
-		when(accountRepository.findUserByEmail(user.getEmail()))
-				.thenReturn(Optional.of(user));
-		when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), any()))
-				.thenReturn(Optional.empty());
+        when(accountRepository.findUserByEmail(user.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), any()))
+                .thenReturn(Optional.empty());
 
-		userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
+        userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
 
-		verify(userLoggedDateRepository, times(1)).findByUserAndLoggedDate(eq(user), any());
-		verify(userLoggedDateRepository, times(1)).save(any(UserLoggedDate.class));
-	}
+        verify(userLoggedDateRepository, times(1)).findByUserAndLoggedDate(eq(user), any());
+        verify(userLoggedDateRepository, times(1)).save(any(UserLoggedDate.class));
+    }
 
-	@DisplayName("When user logs in on five different dates, check if all dates are returned")
-	@Test
-	void whenUserLogsInOnFiveDifferentDatesThenCheckIfAllDatesReturned() {
-		User user = new User();
-		user.setEmail("test@test.com");
-		user.setId(UUID.randomUUID());
+    @DisplayName("When user logs in on five different dates, check if all dates are returned")
+    @Test
+    void whenUserLogsInOnFiveDifferentDatesThenCheckIfAllDatesReturned() {
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setId(UUID.randomUUID());
 
-		Date date1 = Date.valueOf("2024-03-28");
-		Date date2 = Date.valueOf("2024-03-29");
-		Date date3 = Date.valueOf("2024-03-30");
+        Date date1 = Date.valueOf("2024-03-28");
+        Date date2 = Date.valueOf("2024-03-29");
+        Date date3 = Date.valueOf("2024-03-30");
 
-		List<UserLoggedDate> loggedDates = new ArrayList<>();
-		loggedDates.add(new UserLoggedDate(user, date1));
-		loggedDates.add(new UserLoggedDate(user, date2));
-		loggedDates.add(new UserLoggedDate(user, date3));
+        List<UserLoggedDate> loggedDates = new ArrayList<>();
+        loggedDates.add(new UserLoggedDate(user, date1));
+        loggedDates.add(new UserLoggedDate(user, date2));
+        loggedDates.add(new UserLoggedDate(user, date3));
 
-		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail()))
-				.thenReturn(loggedDates);
+        when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail()))
+                .thenReturn(loggedDates);
 
-		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), "desc", null);
+        RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), "desc", null);
 
-		List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
+        List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
 
-		assertEquals(loggedDates.size(), returnedDates.size());
-		assertTrue(returnedDates.contains(date1));
-		assertTrue(returnedDates.contains(date2));
-		assertTrue(returnedDates.contains(date3));
-	}
+        assertEquals(loggedDates.size(), returnedDates.size());
+        assertTrue(returnedDates.contains(date1));
+        assertTrue(returnedDates.contains(date2));
+        assertTrue(returnedDates.contains(date3));
+    }
 
-	@DisplayName("When adding a logged date for an unregistered user, throw NotFoundException")
-	@Test
-	void whenAddingLoggedDateForUnregisteredUserThenThrowNotFoundException() {
-		String email = "unregistered@test.com";
-		java.util.Date loggedDate = new java.util.Date();
+    @DisplayName("When adding a logged date for an unregistered user, throw NotFoundException")
+    @Test
+    void whenAddingLoggedDateForUnregisteredUserThenThrowNotFoundException() {
+        String email = "unregistered@test.com";
+        java.util.Date loggedDate = new java.util.Date();
 
-		when(accountRepository.findUserByEmail(anyString()))
-				.thenReturn(Optional.empty());
+        when(accountRepository.findUserByEmail(anyString()))
+                .thenReturn(Optional.empty());
 
-		assertThrows(NotFoundException.class, () -> {
-			userLoggedDateService.addLoggedDateByEmailAndDate(email, loggedDate);
-		});
-	}
+        assertThrows(NotFoundException.class, () -> {
+            userLoggedDateService.addLoggedDateByEmailAndDate(email, loggedDate);
+        });
+    }
 
-	@DisplayName("When adding a logged date for a user who logged in twice on the same day, do not add it again")
-	@Test
-	void whenAddingLoggedDateForUserWithDuplicateDateThenDoNotAddAgain() throws NotFoundException {
-		User user = new User();
-		user.setEmail("test@test.com");
-		user.setId(UUID.randomUUID());
+    @DisplayName("When adding a logged date for a user who logged in twice on the same day, do not add it again")
+    @Test
+    void whenAddingLoggedDateForUserWithDuplicateDateThenDoNotAddAgain() throws NotFoundException {
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setId(UUID.randomUUID());
 
-		java.util.Date loggedDate = Date.valueOf("2024-03-28");
+        java.util.Date loggedDate = Date.valueOf("2024-03-28");
 
-		when(accountRepository.findUserByEmail(user.getEmail()))
-				.thenReturn(Optional.of(user));
-		when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), eq(DateUtils.convertUtilDateToSqlDate(loggedDate))))
-				.thenReturn(java.util.Optional.of(new UserLoggedDate()));
+        when(accountRepository.findUserByEmail(user.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(userLoggedDateRepository.findByUserAndLoggedDate(eq(user), eq(DateUtils.convertUtilDateToSqlDate(loggedDate))))
+                .thenReturn(java.util.Optional.of(new UserLoggedDate()));
 
-		userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
+        userLoggedDateService.addLoggedDateByEmailAndDate(user.getEmail(), loggedDate);
 
-		verify(userLoggedDateRepository, never()).save(any(UserLoggedDate.class));
+        verify(userLoggedDateRepository, never()).save(any(UserLoggedDate.class));
 
-	}
+    }
 
-	@Test
-	@DisplayName("When fetching logged dates in ascending order, verify sorting")
-	void testGetLoggedDatesAscendingOrderWithNullDaysLimit() {
-		String sort = "asc";
+    @Test
+    @DisplayName("When fetching logged dates in ascending order, verify sorting")
+    void testGetLoggedDatesAscendingOrderWithNullDaysLimit() {
+        String sort = "asc";
 
-		User user = new User();
-		user.setEmail("test@test.com");
-		user.setId(UUID.randomUUID());
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setId(UUID.randomUUID());
 
-		Date date1 = Date.valueOf("2024-03-28");
-		Date date2 = Date.valueOf("2024-03-29");
-		Date date3 = Date.valueOf("2024-03-30");
+        Date date1 = Date.valueOf("2024-03-28");
+        Date date2 = Date.valueOf("2024-03-29");
+        Date date3 = Date.valueOf("2024-03-30");
 
-		List<UserLoggedDate> loggedDates = new ArrayList<>();
-		loggedDates.add(new UserLoggedDate(user, date1));
-		loggedDates.add(new UserLoggedDate(user, date3));
-		loggedDates.add(new UserLoggedDate(user, date2));
+        List<UserLoggedDate> loggedDates = new ArrayList<>();
+        loggedDates.add(new UserLoggedDate(user, date1));
+        loggedDates.add(new UserLoggedDate(user, date3));
+        loggedDates.add(new UserLoggedDate(user, date2));
 
-		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(user.getEmail()))
-				.thenReturn(loggedDates.stream()
-						.sorted(Comparator.comparing(UserLoggedDate::getLoggedDate))
-						.collect(Collectors.toList()));
+        when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateAsc(user.getEmail()))
+                .thenReturn(loggedDates.stream()
+                        .sorted(Comparator.comparing(UserLoggedDate::getLoggedDate))
+                        .collect(Collectors.toList()));
 
-		RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), sort, null);
+        RUserLoggedDate returnedUserLoggedDates = userLoggedDateService.getLoggedDates(user.getEmail(), sort, null);
 
-		List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
+        List<Date> returnedDates = returnedUserLoggedDates.getLoggedDates();
 
-		assertNotNull(returnedDates);
-		for (int i = 0; i < returnedDates.size() - 1; i++) {
-			assertTrue(returnedDates.get(i).before(returnedDates.get(i + 1)) || returnedDates.get(i).equals(returnedDates.get(i + 1)));
-		}
-		assertEquals(loggedDates.size(), returnedDates.size());
-	}
+        assertNotNull(returnedDates);
+        for (int i = 0; i < returnedDates.size() - 1; i++) {
+            assertTrue(returnedDates.get(i).before(returnedDates.get(i + 1)) || returnedDates.get(i).equals(returnedDates.get(i + 1)));
+        }
+        assertEquals(loggedDates.size(), returnedDates.size());
+    }
 
-	@DisplayName("When getting logged dates for a user who never logged in, verify empty list is returned")
-	@Test
-	void whenGettingLoggedDatesForUserNeverLoggedInThenVerifyEmptyList() throws NotFoundException {
-		User user = new User();
-		user.setEmail("test@test.com");
-		user.setId(UUID.randomUUID());
+    @DisplayName("When getting logged dates for a user who never logged in, verify empty list is returned")
+    @Test
+    void whenGettingLoggedDatesForUserNeverLoggedInThenVerifyEmptyList() {
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setId(UUID.randomUUID());
 
-		when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail())).thenReturn(Collections.emptyList());
+        when(userLoggedDateRepository.findByUserEmailOrderByLoggedDateDesc(user.getEmail())).thenReturn(Collections.emptyList());
 
-		RUserLoggedDate rUserLoggedDate = userLoggedDateService.getLoggedDates(user.getEmail(), null, null);
+        RUserLoggedDate rUserLoggedDate = userLoggedDateService.getLoggedDates(user.getEmail(), null, null);
 
-		assertTrue(rUserLoggedDate.getLoggedDates().isEmpty());
-	}
+        assertTrue(rUserLoggedDate.getLoggedDates().isEmpty());
+    }
 }

--- a/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/stats/UserLoggedDateServiceTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import app.linguistai.bmvp.consts.Parameter;
 import app.linguistai.bmvp.exception.NotFoundException;
 import app.linguistai.bmvp.model.User;
 import app.linguistai.bmvp.model.stats.UserLoggedDate;
@@ -124,7 +125,7 @@ public class UserLoggedDateServiceTest {
     @Test
     @DisplayName("When fetching logged dates in ascending order, verify sorting")
     void testGetLoggedDatesAscendingOrderWithNullDaysLimit() {
-        String sort = "asc";
+        String sort = Parameter.ASCENDING_ORDER;
 
         User user = new User();
         user.setEmail("test@test.com");


### PR DESCRIPTION
Dates when the user logs in are recorded in the user_logged_date table. The users' logged dates can be viewed through the `/stats/logged-date` endpoint. The view can be sorted and can be limited by the number of days (e.g., displaying only the logged days from the last 50 days).

Please note that current dates are always obtained from the server's timezone.