### PR TITLE
feat(LINGUIST-344): Word confidence stats for all lists

### DIFF
--- a/src/main/java/app/linguistai/bmvp/controller/AccountController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/AccountController.java
@@ -1,5 +1,6 @@
 package app.linguistai.bmvp.controller;
 
+import java.util.Date;
 import java.util.List;
 
 import app.linguistai.bmvp.model.ResetToken;
@@ -7,6 +8,8 @@ import app.linguistai.bmvp.request.QResetPassword;
 import app.linguistai.bmvp.request.QResetPasswordVerification;
 import app.linguistai.bmvp.request.QUser;
 import app.linguistai.bmvp.request.QResetPasswordSave;
+import app.linguistai.bmvp.service.gamification.UserStreakService;
+import app.linguistai.bmvp.service.stats.UserLoggedDateService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -40,6 +43,8 @@ import lombok.AllArgsConstructor;
 public class AccountController {
     private final AccountService accountService;
     private final EmailService emailService;
+    private final UserLoggedDateService userLoggedDateService;
+    private final UserStreakService userStreakService;
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, path = "login")
     public ResponseEntity<Object> login(@Valid @RequestBody QUserLogin userInfo) {
@@ -85,9 +90,11 @@ public class AccountController {
     }
 
     @GetMapping("/test")
-    public ResponseEntity<Object> testAuth() {
+    public ResponseEntity<Object> testAuth(@RequestHeader(Header.USER_EMAIL) String email) {
         try {
             String test = "Welcome to the authenticated endpoint!";
+            userLoggedDateService.addLoggedDateByEmailAndDate(email, new Date());
+            userStreakService.updateUserStreak(email);
             return Response.create("ok", HttpStatus.OK, test);
         } catch (Exception e) {
             return Response.create(ExceptionLogger.log(e), HttpStatus.BAD_REQUEST);

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -171,4 +171,13 @@ public class UnknownWordController {
             return Response.create(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @GetMapping("/lists/stats")
+    public ResponseEntity<Object> getListStats(@RequestHeader(Header.USER_EMAIL) String email) {
+        try {
+            return Response.create("Successfully retrieved statistics for all word lists.", HttpStatus.OK, unknownWordService.getAllListStats(email));
+        } catch (Exception e) {
+            return Response.create(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -1,9 +1,16 @@
 package app.linguistai.bmvp.controller;
 
 import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.exception.NotFoundException;
 import app.linguistai.bmvp.request.wordbank.*;
 import app.linguistai.bmvp.response.Response;
+import app.linguistai.bmvp.response.wordbank.RUnknownWordListsStats;
 import app.linguistai.bmvp.service.wordbank.IUnknownWordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 
@@ -172,11 +179,23 @@ public class UnknownWordController {
         }
     }
 
+    @Operation(summary = "Get Word Stats", description = "Returns the mastered/reviewing/learning stats for words in all word lists")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content =
+                    { @Content(mediaType = "application/json", schema =
+                    @Schema(implementation = RUnknownWordListsStats.class)) }),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @GetMapping("/lists/stats")
-    public ResponseEntity<Object> getListStats(@RequestHeader(Header.USER_EMAIL) String email) {
+    public ResponseEntity<Object> getAllListStats(@RequestHeader(Header.USER_EMAIL) String email) {
         try {
             return Response.create("Successfully retrieved statistics for all word lists.", HttpStatus.OK, unknownWordService.getAllListStats(email));
-        } catch (Exception e) {
+        }
+        catch (NotFoundException e) {
+            return Response.create(e.getMessage(), HttpStatus.NOT_FOUND);
+        }
+        catch (Exception e) {
             return Response.create(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/app/linguistai/bmvp/model/wordbank/IConfidenceCount.java
+++ b/src/main/java/app/linguistai/bmvp/model/wordbank/IConfidenceCount.java
@@ -1,0 +1,8 @@
+package app.linguistai.bmvp.model.wordbank;
+
+import app.linguistai.bmvp.model.enums.ConfidenceEnum;
+
+public interface IConfidenceCount {
+    ConfidenceEnum getConfidence();
+    Long getCount();
+}

--- a/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordRepository.java
@@ -1,9 +1,10 @@
-
 package app.linguistai.bmvp.repository.wordbank;
 
 import app.linguistai.bmvp.model.embedded.UnknownWordId;
 import app.linguistai.bmvp.model.wordbank.UnknownWord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +13,7 @@ import java.util.UUID;
 public interface IUnknownWordRepository extends JpaRepository<UnknownWord, UnknownWordId> {
     List<UnknownWord> findByOwnerListListId(UUID listId);
     Optional<UnknownWord> findByOwnerListListIdAndWord(UUID listId, String word);
+
+    @Query("SELECT u.confidence, COUNT(u) FROM UnknownWord u WHERE u.ownerList.user.id = :userId GROUP BY u.confidence")
+    List<Object[]> countWordsByConfidenceLevel(@Param("userId") UUID userId);
 }

--- a/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordRepository.java
@@ -1,6 +1,7 @@
 package app.linguistai.bmvp.repository.wordbank;
 
 import app.linguistai.bmvp.model.embedded.UnknownWordId;
+import app.linguistai.bmvp.model.wordbank.IConfidenceCount;
 import app.linguistai.bmvp.model.wordbank.UnknownWord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,6 @@ public interface IUnknownWordRepository extends JpaRepository<UnknownWord, Unkno
     List<UnknownWord> findByOwnerListListId(UUID listId);
     Optional<UnknownWord> findByOwnerListListIdAndWord(UUID listId, String word);
 
-    @Query("SELECT u.confidence, COUNT(u) FROM UnknownWord u WHERE u.ownerList.user.id = :userId GROUP BY u.confidence")
-    List<Object[]> countWordsByConfidenceLevel(@Param("userId") UUID userId);
+    @Query("SELECT u.confidence AS confidence, COUNT(u) AS count FROM UnknownWord u WHERE u.ownerList.user.id = :userId GROUP BY u.confidence")
+    List<IConfidenceCount> countWordsByConfidenceLevel(@Param("userId") UUID userId);
 }

--- a/src/main/java/app/linguistai/bmvp/response/wordbank/RUnknownWordListsStats.java
+++ b/src/main/java/app/linguistai/bmvp/response/wordbank/RUnknownWordListsStats.java
@@ -1,0 +1,13 @@
+package app.linguistai.bmvp.response.wordbank;
+
+import app.linguistai.bmvp.model.wordbank.ListStats;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RUnknownWordListsStats {
+    private ListStats listStats;
+}

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
@@ -6,6 +6,7 @@ import app.linguistai.bmvp.response.wordbank.ROwnerUnknownWordList;
 import app.linguistai.bmvp.response.wordbank.RUnknownWord;
 import app.linguistai.bmvp.response.wordbank.RUnknownWordListWords;
 import app.linguistai.bmvp.response.wordbank.RUnknownWordLists;
+import app.linguistai.bmvp.response.wordbank.RUnknownWordListsStats;
 
 import java.util.UUID;
 
@@ -24,4 +25,5 @@ public interface IUnknownWordService {
     ROwnerUnknownWordList pinList(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList unpinList(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList deleteList(UUID listId, String email) throws Exception;
+    RUnknownWordListsStats getAllListStats(String email) throws Exception;
 }


### PR DESCRIPTION
Related endpoint: /wordbank/lists/stats. Example returned data field: 
"listStats": {
            "mastered": 1,
            "reviewing": 2,
            "learning": 7
        }

Also changed the test endpoint to add service calls to logged date and user streak.