### PR TITLE
feat(LINGUIST-348): Basic store functions implemented

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/StoreConsts.java
+++ b/src/main/java/app/linguistai/bmvp/consts/StoreConsts.java
@@ -1,0 +1,19 @@
+package app.linguistai.bmvp.consts;
+
+public class StoreConsts {
+    // Types
+    public static final String TYPE_DOUBLE_ANSWER = "Double Answer";
+    public static final String TYPE_ELIMINATE_WRONG_ANSWER = "Eliminate Wrong Answer";
+
+    // Descriptions
+    public static final String DESCRIPTION_DOUBLE_ANSWER = "Unlock the ability to answer a question twice for better practice.";
+    public static final String DESCRIPTION_ELIMINATE_WRONG_ANSWER = "Unlock the ability to eliminate one wrong answer choice during a quiz.";
+
+    // Prices
+    public static final Long PRICE_DOUBLE_ANSWER = 100L;
+    public static final Long PRICE_ELIMINATE_WRONG_ANSWER = 50L;
+
+    // Enabled status
+    public static final boolean ENABLED_DOUBLE_ANSWER = true;
+    public static final boolean ENABLED_ELIMINATE_WRONG_ANSWER = true;
+}

--- a/src/main/java/app/linguistai/bmvp/controller/gamification/StoreController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/gamification/StoreController.java
@@ -1,0 +1,95 @@
+package app.linguistai.bmvp.controller.gamification;
+
+import app.linguistai.bmvp.response.gamification.store.RStoreItems;
+import app.linguistai.bmvp.response.gamification.store.RUserItem;
+import app.linguistai.bmvp.response.gamification.store.RUserItems;
+import app.linguistai.bmvp.service.gamification.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.response.Response;
+import lombok.AllArgsConstructor;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("store")
+@Tag(name = "Store")
+public class StoreController {
+    private final StoreService storeService;
+
+    @GetMapping("/all")
+    @Operation(summary = "Get all store items", description = "Retrieves all store items, enabled or disabled")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully fetched all store items", content =
+                    {@Content(mediaType = "application/json", array = @ArraySchema(schema =
+                    @Schema(implementation = RStoreItems.class)))}),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> getAllStoreItems(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) throws Exception {
+        return Response.create("Successfully fetched all store items", HttpStatus.OK, storeService.getAllStoreItems(page, size));
+    }
+
+    @GetMapping("/all-enabled")
+    @Operation(summary = "Get all enabled store items", description = "Retrieves all enabled store items")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully fetched all enabled store items", content =
+                    {@Content(mediaType = "application/json", array = @ArraySchema(schema =
+                    @Schema(implementation = RStoreItems.class)))}),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> getAllEnabledStoreItems(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) throws Exception {
+        return Response.create("Successfully fetched all enabled store items", HttpStatus.OK, storeService.getAllEnabledStoreItems(page, size));
+    }
+
+
+    @GetMapping("/user-items")
+    @Operation(summary = "Get user items", description = "Retrieves a user's items and their quantity")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully fetched all user items", content =
+                    {@Content(mediaType = "application/json", array = @ArraySchema(schema =
+                    @Schema(implementation = RUserItems.class)))}),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> getUserItems(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) throws Exception {
+        return Response.create("Successfully fetched all user items", HttpStatus.OK, storeService.getUserItems(email, page, size));
+    }
+
+    @PostMapping("/purchase")
+    @Operation(summary = "Purchase user item", description = "Purchases a user item")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Item purchased successfully", content =
+                    {@Content(mediaType = "application/json", schema =
+                    @Schema(implementation = RUserItem.class))}),
+            @ApiResponse(responseCode = "404", description = "User or store item not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> purchaseUserItem(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam @NotBlank UUID itemId) throws Exception {
+        return Response.create("Item purchased successfully", HttpStatus.OK, storeService.purchaseUserItem(email, itemId));
+    }
+
+    @PostMapping("/user-items/decrease-quantity")
+    @Operation(summary = "Decrease user item quantity", description = "Decreases the quantity of a user item")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User item quantity decreased successfully", content =
+                    {@Content(mediaType = "application/json", schema =
+                    @Schema(implementation = RUserItem.class))}),
+            @ApiResponse(responseCode = "404", description = "User, store item or the user item not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> decreaseUserItemQuantity(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam @NotBlank UUID itemId) throws Exception {
+        return Response.create("User item quantity decreased successfully", HttpStatus.OK, storeService.decreaseUserItemQuantity(email, itemId));
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/exception/store/InsufficientUserItemQuantityException.java
+++ b/src/main/java/app/linguistai/bmvp/exception/store/InsufficientUserItemQuantityException.java
@@ -1,0 +1,10 @@
+package app.linguistai.bmvp.exception.store;
+
+import app.linguistai.bmvp.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InsufficientUserItemQuantityException extends CustomException {
+    public InsufficientUserItemQuantityException() {
+        super("Not enough items", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/exception/store/ItemNotEnabledException.java
+++ b/src/main/java/app/linguistai/bmvp/exception/store/ItemNotEnabledException.java
@@ -1,0 +1,10 @@
+package app.linguistai.bmvp.exception.store;
+
+import app.linguistai.bmvp.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ItemNotEnabledException extends CustomException {
+    public ItemNotEnabledException() {
+        super("Store item is not enabled", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/model/embedded/UserItemId.java
+++ b/src/main/java/app/linguistai/bmvp/model/embedded/UserItemId.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.model.embedded;
+
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserItemId implements Serializable {
+    private User user;
+    private StoreItem storeItem;
+}

--- a/src/main/java/app/linguistai/bmvp/model/gamification/store/StoreItem.java
+++ b/src/main/java/app/linguistai/bmvp/model/gamification/store/StoreItem.java
@@ -1,0 +1,46 @@
+package app.linguistai.bmvp.model.gamification.store;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@Entity
+@Table(name = "store_item")
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @NotBlank
+    @Column(name = "type", nullable = false, unique = true)
+    private String type;
+
+    @NotBlank
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @NotNull
+    @Column(name = "gem_price", nullable = false)
+    private Long gemPrice;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    public StoreItem(String type, String description, Long gemPrice, boolean enabled) {
+        this.type = type;
+        this.description = description;
+        this.gemPrice = gemPrice;
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/model/gamification/store/UserItem.java
+++ b/src/main/java/app/linguistai/bmvp/model/gamification/store/UserItem.java
@@ -1,0 +1,31 @@
+package app.linguistai.bmvp.model.gamification.store;
+
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.embedded.UserItemId;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@Entity
+@Table(name = "user_item")
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(UserItemId.class)
+public class UserItem {
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", insertable = false, nullable = false)
+    private User user;
+
+    @Id
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "storeItem", referencedColumnName = "id", nullable = false)
+    private StoreItem storeItem;
+
+    @Column(name = "quantity")
+    private int quantity;
+}

--- a/src/main/java/app/linguistai/bmvp/repository/gamification/store/IStoreItemRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/gamification/store/IStoreItemRepository.java
@@ -1,0 +1,16 @@
+package app.linguistai.bmvp.repository.gamification.store;
+
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface IStoreItemRepository extends JpaRepository<StoreItem, UUID> {
+    Page<StoreItem> findByEnabled(boolean enabled, Pageable pageable);
+    Optional<StoreItem> findByType(String type);
+}

--- a/src/main/java/app/linguistai/bmvp/repository/gamification/store/IUserItemRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/gamification/store/IUserItemRepository.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.repository.gamification.store;
+
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.embedded.UserItemId;
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import app.linguistai.bmvp.model.gamification.store.UserItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface IUserItemRepository extends JpaRepository<UserItem, UserItemId> {
+    Page<UserItem> findByUser(User user, Pageable page);
+    Optional<UserItem> findByUserAndStoreItem(User user, StoreItem storeItem);
+}

--- a/src/main/java/app/linguistai/bmvp/response/gamification/store/RStoreItem.java
+++ b/src/main/java/app/linguistai/bmvp/response/gamification/store/RStoreItem.java
@@ -1,0 +1,13 @@
+package app.linguistai.bmvp.response.gamification.store;
+
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RStoreItem {
+    private StoreItem storeItem;
+}

--- a/src/main/java/app/linguistai/bmvp/response/gamification/store/RStoreItems.java
+++ b/src/main/java/app/linguistai/bmvp/response/gamification/store/RStoreItems.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.response.gamification.store;
+
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RStoreItems {
+    private List<RStoreItem> storeItems;
+    private int totalPages;
+    private int currentPage;
+    private int pageSize;
+}

--- a/src/main/java/app/linguistai/bmvp/response/gamification/store/RUserItem.java
+++ b/src/main/java/app/linguistai/bmvp/response/gamification/store/RUserItem.java
@@ -1,0 +1,13 @@
+package app.linguistai.bmvp.response.gamification.store;
+
+import app.linguistai.bmvp.model.gamification.store.UserItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RUserItem {
+    private UserItem userItem;
+}

--- a/src/main/java/app/linguistai/bmvp/response/gamification/store/RUserItems.java
+++ b/src/main/java/app/linguistai/bmvp/response/gamification/store/RUserItems.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.response.gamification.store;
+
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RUserItems {
+    private List<RUserItem> userItems;
+    private int totalPages;
+    private int currentPage;
+    private int pageSize;
+}

--- a/src/main/java/app/linguistai/bmvp/service/gamification/StoreItemLoader.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/StoreItemLoader.java
@@ -1,0 +1,52 @@
+package app.linguistai.bmvp.service.gamification;
+
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import app.linguistai.bmvp.repository.gamification.store.IStoreItemRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import static app.linguistai.bmvp.consts.StoreConsts.*;
+
+@Slf4j
+@Component
+public class StoreItemLoader implements ApplicationRunner {
+
+    private final IStoreItemRepository storeItemRepository;
+
+    @Autowired
+    public StoreItemLoader(IStoreItemRepository storeItemRepository) {
+        this.storeItemRepository = storeItemRepository;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        StoreItem[] storeItems = {
+                new StoreItem(TYPE_DOUBLE_ANSWER, DESCRIPTION_DOUBLE_ANSWER, PRICE_DOUBLE_ANSWER, ENABLED_DOUBLE_ANSWER),
+                new StoreItem(TYPE_ELIMINATE_WRONG_ANSWER, DESCRIPTION_ELIMINATE_WRONG_ANSWER, PRICE_ELIMINATE_WRONG_ANSWER, ENABLED_ELIMINATE_WRONG_ANSWER),
+        };
+
+        try {
+            // Save store items by updating the existing ones and creating new items for new "types"
+            for (StoreItem newItem : storeItems) {
+                StoreItem existingItem = storeItemRepository.findByType(newItem.getType()).orElse(null);
+                if (existingItem != null) {
+                    existingItem.setDescription(newItem.getDescription());
+                    existingItem.setGemPrice(newItem.getGemPrice());
+                    existingItem.setEnabled(newItem.isEnabled());
+                    storeItemRepository.save(existingItem);
+                } else {
+                    storeItemRepository.save(newItem);
+                }
+            }
+            log.info("Store items loaded into the database successfully.");
+        } catch (DataIntegrityViolationException e) {
+            log.info("Store items already exist in the database.");
+        } catch (Exception e) {
+            log.error("Failed to load store items.", e);
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/service/gamification/StoreService.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/StoreService.java
@@ -1,0 +1,206 @@
+package app.linguistai.bmvp.service.gamification;
+
+import app.linguistai.bmvp.exception.store.InsufficientUserItemQuantityException;
+import app.linguistai.bmvp.exception.NotFoundException;
+import app.linguistai.bmvp.exception.SomethingWentWrongException;
+import app.linguistai.bmvp.exception.currency.InsufficientGemsException;
+import app.linguistai.bmvp.exception.store.ItemNotEnabledException;
+import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.model.enums.TransactionType;
+import app.linguistai.bmvp.model.gamification.store.StoreItem;
+import app.linguistai.bmvp.model.gamification.store.UserItem;
+import app.linguistai.bmvp.repository.IAccountRepository;
+import app.linguistai.bmvp.repository.gamification.store.IStoreItemRepository;
+import app.linguistai.bmvp.repository.gamification.store.IUserItemRepository;
+import app.linguistai.bmvp.response.gamification.store.RStoreItem;
+import app.linguistai.bmvp.response.gamification.store.RStoreItems;
+import app.linguistai.bmvp.response.gamification.store.RUserItem;
+import app.linguistai.bmvp.response.gamification.store.RUserItems;
+import app.linguistai.bmvp.service.currency.TransactionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class StoreService {
+    private final IStoreItemRepository storeItemRepository;
+    private final IUserItemRepository userItemRepository;
+    private final IAccountRepository accountRepository;
+
+    private final TransactionService transactionService;
+
+    @Transactional(readOnly = true)
+    public RStoreItems getAllStoreItems(int page, int size) throws Exception {
+        try {
+            Pageable pageable = PageRequest.of(page, size);
+            Page<StoreItem> storeItemsPage = storeItemRepository.findAll(pageable);
+            List<RStoreItem> storeItems = storeItemsPage.getContent().stream().map(RStoreItem::new).collect(Collectors.toList());
+
+            // Build a response and return all store items, enabled or disabled
+            RStoreItems response = RStoreItems.builder().storeItems(storeItems)
+                    .totalPages(storeItemsPage.getTotalPages())
+                    .currentPage(storeItemsPage.getNumber())
+                    .pageSize(storeItemsPage.getSize())
+                    .build();
+            log.info("All store items are fetched.");
+            return response;
+        } catch (Exception e) {
+            log.error("Fetching store items failed", e);
+            throw new SomethingWentWrongException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public RStoreItems getAllEnabledStoreItems(int page, int size) throws SomethingWentWrongException {
+        try {
+            Pageable pageable = PageRequest.of(page, size);
+            Page<StoreItem> enabledStoreItemsPage = storeItemRepository.findByEnabled(true, pageable);
+            List<RStoreItem> enabledStoreItems = enabledStoreItemsPage.getContent().stream().map(RStoreItem::new).collect(Collectors.toList());
+
+            // Build a response and return all enabled store items
+            RStoreItems response = RStoreItems.builder().storeItems(enabledStoreItems)
+                    .totalPages(enabledStoreItemsPage.getTotalPages())
+                    .currentPage(enabledStoreItemsPage.getNumber())
+                    .pageSize(enabledStoreItemsPage.getSize())
+                    .build();
+            log.info("All enabled store items are fetched.");
+            return response;
+        } catch (Exception e) {
+            log.error("Fetching enabled store items failed", e);
+            throw new SomethingWentWrongException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public RUserItems getUserItems(String email, int page, int size) throws Exception {
+        try {
+            User user = accountRepository.findUserByEmail(email).orElseThrow(() -> new NotFoundException(User.class.getSimpleName(), true));
+            Pageable pageable = PageRequest.of(page, size);
+            Page<UserItem> userItemsPage = userItemRepository.findByUser(user, pageable);
+            List<RUserItem> userItems = userItemsPage.getContent().stream()
+                    .map(RUserItem::new)
+                    .collect(Collectors.toList());
+
+            // Build a response and return user's all items
+            RUserItems response = RUserItems.builder().userItems(userItems)
+                    .totalPages(userItemsPage.getTotalPages())
+                    .currentPage(userItemsPage.getNumber())
+                    .pageSize(userItemsPage.getSize())
+                    .build();
+            log.info("All user items are fetched for user with email {}", email);
+            return response;
+        } catch (NotFoundException e) {
+            log.error("Fetching user items failed since user does not exist for email {}", email);
+            throw e;
+        } catch (Exception e) {
+            log.error("Fetching user items failed for user with email {}", email, e);
+            throw new SomethingWentWrongException();
+        }
+    }
+
+    @Transactional
+    public RUserItem purchaseUserItem(String email, UUID storeItemId) throws Exception {
+        try {
+            User user = accountRepository.findUserByEmail(email)
+                    .orElseThrow(() -> new NotFoundException(User.class.getSimpleName(), true));
+
+            StoreItem storeItem = storeItemRepository.findById(storeItemId)
+                    .orElseThrow(() -> new NotFoundException(StoreItem.class.getSimpleName(), true));
+
+            // Check if the store item is enabled
+            if (!storeItem.isEnabled()) {
+                throw new ItemNotEnabledException();
+            }
+
+            transactionService.processTransaction(email, TransactionType.SHOP_SPEND, storeItem.getGemPrice());
+
+            // If the user already has the item, increment the quantity, otherwise create a new UserItem
+            UserItem userItem = userItemRepository.findByUserAndStoreItem(user, storeItem)
+                    .map(item -> {
+                        item.setQuantity(item.getQuantity() + 1);
+                        return item;
+                    })
+                    .orElseGet(() -> new UserItem(user, storeItem, 1));
+
+            // Save the user item
+            userItemRepository.save(userItem);
+
+            log.info("User {} purchased item {} successfully", email, storeItem.getType());
+            return RUserItem.builder().userItem(userItem).build();
+        } catch (NotFoundException e) {
+            if (e.getObject().equals(User.class.getSimpleName())) {
+                log.error("When purchasing an item, user is not found for email {}", email);
+            } else {
+                log.error("When purchasing an item, store item is not found for id {}", storeItemId);
+            }
+            throw e;
+        } catch (ItemNotEnabledException e) {
+            log.error("Store item with id {} is not enabled for purchase", storeItemId);
+            throw e;
+        }  catch (InsufficientGemsException e) {
+            log.error("Not enough gems for user with email {}", email);
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to purchase item", e);
+            throw new SomethingWentWrongException("Failed to purchase item");
+        }
+    }
+
+    @Transactional
+    public RUserItem decreaseUserItemQuantity(String email, UUID storeItemId) throws Exception {
+        try {
+            User user = accountRepository.findUserByEmail(email)
+                    .orElseThrow(() -> new NotFoundException(User.class.getSimpleName(), true));
+
+            StoreItem storeItem = storeItemRepository.findById(storeItemId)
+                    .orElseThrow(() -> new NotFoundException(StoreItem.class.getSimpleName(), true));
+
+            UserItem userItem = userItemRepository.findByUserAndStoreItem(user, storeItem)
+                    .orElseThrow(() -> new NotFoundException(UserItem.class.getSimpleName(), true));
+
+            if (userItem.getQuantity() <= 0) {
+                throw new InsufficientUserItemQuantityException();
+            }
+
+            // Consume one unit of the user item
+            userItem.setQuantity(userItem.getQuantity() - 1);
+
+            if (userItem.getQuantity() <= 0) {
+                // If quantity becomes 0 or negative, delete the user item
+                userItemRepository.delete(userItem);
+            } else {
+                // Otherwise, save the updated user item
+                userItemRepository.save(userItem);
+            }
+
+            log.info("User item consumed successfully for user with email {}", email);
+            return RUserItem.builder().userItem(userItem).build();
+        } catch (NotFoundException e) {
+            if (e.getObject().equals(User.class.getSimpleName())) {
+                log.error("When decreasing user item quantity, user is not found for email {}", email);
+            } else if (e.getObject().equals(StoreItem.class.getSimpleName())) {
+                log.error("When decreasing user item quantity, store item is not found for id {}", storeItemId);
+            } else {
+                log.error("When decreasing user item quantity, user item is not found for user email {} and store item id {}",
+                        email, storeItemId);
+            }
+            throw e;
+        } catch (InsufficientUserItemQuantityException e) {
+            log.error("User item quantity cannot be decreased since it is 0 or negative for user with email {}", email);
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to decrease user item quantity for user with email {}", email, e);
+            throw new SomethingWentWrongException();
+        }
+    }
+}

--- a/src/main/java/app/linguistai/bmvp/service/profile/HobbyLoader.java
+++ b/src/main/java/app/linguistai/bmvp/service/profile/HobbyLoader.java
@@ -1,5 +1,6 @@
 package app.linguistai.bmvp.service.profile;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -11,6 +12,7 @@ import app.linguistai.bmvp.repository.IHobbyRepository;
 
 import java.util.Arrays;
 
+@Slf4j
 @Component
 public class HobbyLoader implements ApplicationRunner {
 
@@ -58,9 +60,11 @@ public class HobbyLoader implements ApplicationRunner {
         
         try {
             hobbyRepository.saveAll(Arrays.asList(hobbies));
+            log.info("Hobbies loaded into the database successfully.");
         } catch (DataIntegrityViolationException e) {
-            System.out.println("Hobbies already exist");
+            log.info("Hobbies already exist in the database.");
         } catch (Exception e) {
+            log.error("Failed to load hobbies.", e);
             e.printStackTrace();
         }        
     }


### PR DESCRIPTION
This PR implements basic store functionality, such as adding new items, "purchasing" them, and consuming them. The logic for each item's functionality is outside the scope of LINGUIST-348.

New store items' fields can be defined in the StoreConsts and manually added to the StoreLoader for the app to load the items on boot. 

If an existing store item's fields are changed (provided the type name is not changed, as it is a unique field) then the store item is updated. This way, we can enable/disable an existing item by changing the related constant in StoreConsts. I thought about creating an endpoint for this, but since we do not have an admin user class, any logged-in user would have been able to enable an item.


