### PR TITLE
fix(LINGUIST-393): Leaderboard secondly ordered by username

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/LeaderboardConsts.java
+++ b/src/main/java/app/linguistai/bmvp/consts/LeaderboardConsts.java
@@ -2,4 +2,5 @@ package app.linguistai.bmvp.consts;
 
 public class LeaderboardConsts {
     public static final String XP_SORT_FIELD = "experience";
+    public static final String USERNAME_SORT_FIELD = "user.username";
 }

--- a/src/main/java/app/linguistai/bmvp/repository/gamification/IUserXPRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/gamification/IUserXPRepository.java
@@ -13,23 +13,31 @@ import java.util.UUID;
 public interface IUserXPRepository extends JpaRepository<UserXP, UUID> {
     @Query("SELECT ux FROM UserXP ux " +
             "JOIN Friendship f ON (ux.user.id = f.user1.id OR ux.user.id = f.user2.id) " +
+            "JOIN User u ON (u.id = ux.user.id) " +
             "WHERE (f.user1.id = :userId OR f.user2.id = :userId) " +
             "AND f.status = 1 " +
-            "ORDER BY ux.experience DESC")
+            "ORDER BY ux.experience DESC, u.username")
     Page<UserXP> findTopFriendsByExperience(UUID userId, Pageable pageable);
 
-    @Query(value = "SELECT r.ranking, r.userIdAsByte, r.experience FROM (SELECT DENSE_RANK() OVER (ORDER BY ux.experience DESC) AS ranking, u.email AS email, ux.experience, ux.user_id as userIdAsByte " +
+    @Query(value = "SELECT r.ranking, r.userIdAsByte, r.experience FROM (SELECT DENSE_RANK() OVER (ORDER BY ux.experience DESC, u.username) AS ranking, u.email AS email, ux.experience, ux.user_id as userIdAsByte " +
             "FROM user_xp ux JOIN user u ON u.id = ux.user_id) AS r WHERE r.email = :email",
             nativeQuery = true)
     Optional<IXPRanking> findGlobalUserRankByEmail(String email);
 
-    @Query(value = "SELECT r.ranking, r.userIdAsByte, r.experience FROM (SELECT DENSE_RANK() OVER (ORDER BY ux.experience DESC) AS ranking, ux.experience, ux.user_id as userIdAsByte " +
-            "FROM user_xp ux " +
-            "JOIN friendship f ON (ux.user_id = f.user1 OR ux.user_id = f.user2) " +
-            "WHERE (f.user1 = :userId OR f.user2 = :userId) " +
-            "AND f.status = 1) AS r " +
-            "WHERE r.userIdAsByte = :userId",
+    @Query(value = "SELECT r.ranking, r.userIdAsByte, r.experience FROM (SELECT DENSE_RANK() OVER (ORDER BY user_friends.experience DESC, u.username) AS ranking, user_friends.experience, user_friends.user_id as userIdAsByte " +
+            "FROM (SELECT ux.* FROM user_xp ux " +
+            "JOIN friendship f ON ux.user_id = f.user2 " +
+            "WHERE f.user1 = :userId AND f.status = 1 " +
+            "UNION " +
+            "SELECT ux.* FROM user_xp ux " +
+            "JOIN friendship f ON ux.user_id = f.user1 " +
+            "WHERE f.user2 = :userId AND f.status = 1 " +
+            "UNION " +
+            "SELECT ux.* FROM user_xp ux " +
+            "WHERE ux.user_id = :userId) AS user_friends " +
+            "JOIN user u ON u.id = user_friends.user_id) AS r " +
+            "WHERE userIdAsByte = :userId",
             nativeQuery = true)
-    Optional<IXPRanking> findFriendsUserRankByEmail(UUID userId);
+    Optional<IXPRanking> findFriendsUserRankById(UUID userId);
 
 }

--- a/src/main/java/app/linguistai/bmvp/service/gamification/LeaderboardService.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/LeaderboardService.java
@@ -9,7 +9,7 @@ import app.linguistai.bmvp.repository.IAccountRepository;
 import app.linguistai.bmvp.repository.gamification.IUserXPRepository;
 import app.linguistai.bmvp.response.gamification.RLeaderboardXP;
 import app.linguistai.bmvp.response.gamification.RUserXPRanking;
-import app.linguistai.bmvp.consts.LeaderboardConsts;
+import static app.linguistai.bmvp.consts.LeaderboardConsts.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,7 +42,7 @@ public class LeaderboardService {
             }
 
             // Create pageable object with the given page number and size for pagination
-            Pageable pageable = PageRequest.of(page, size, Sort.by(LeaderboardConsts.XP_SORT_FIELD).descending());
+            Pageable pageable = PageRequest.of(page, size, Sort.by(XP_SORT_FIELD).descending().and(Sort.by(USERNAME_SORT_FIELD)));
             // Fetch page of user XP records sorted by experience
             Page<UserXP> userXPPage = xpRepository.findAll(pageable);
 
@@ -68,7 +68,7 @@ public class LeaderboardService {
             }
 
             // Fetch the ranking of the logged-in user among friends
-            IXPRanking loggedUserRanking = xpRepository.findFriendsUserRankByEmail(loggedUser.getId())
+            IXPRanking loggedUserRanking = xpRepository.findFriendsUserRankById(loggedUser.getId())
                     .orElseThrow(() -> new NotFoundException("User's XP ranking among friends", true));
 
             // If page number is not given, then return the page where the user is present


### PR DESCRIPTION
Leaderboard is now first ordered by XP, then by username to avoid random ordering when users' XPs are equal. 