### PR TITLE
fix(LINGUIST-373): Word lists ordered by pinned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ build/
 ### VS Code ###
 .vscode/
 secrets.properties
+*.log
 /logs
 *.gz

--- a/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordListRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/wordbank/IUnknownWordListRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface IUnknownWordListRepository extends JpaRepository<UnknownWordList, UUID> {
     List<UnknownWordList> findByUserId(UUID userId);
+    List<UnknownWordList> findByUserIdOrderByIsPinnedDesc(UUID userId);
 }

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -53,7 +53,7 @@ public class UnknownWordService implements IUnknownWordService {
             User user = accountRepository.findUserByEmail(email)
                 .orElseThrow(() -> new NotFoundException("User does not exist for given email: [" + email + "]."));
 
-            List<UnknownWordList> listsOfUser = listRepository.findByUserId(user.getId());
+            List<UnknownWordList> listsOfUser = listRepository.findByUserIdOrderByIsPinnedDesc(user.getId());
             List<RUnknownWordList> responseListsOfUser = new ArrayList<>();
 
             for (UnknownWordList list : listsOfUser) {

--- a/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
@@ -77,7 +77,7 @@ class UnknownWordServiceTest {
             .isPinned(false)
             .imageUrl("imageUrl")
             .build());
-        when(listRepository.findByUserId(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
+        when(listRepository.findByUserIdOrderByIsPinnedDesc(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
             .thenReturn(unknownWordLists);
 
         // Configure IUnknownWordListRepository.findById(...).
@@ -151,7 +151,7 @@ class UnknownWordServiceTest {
             .isPinned(false)
             .imageUrl("imageUrl")
             .build());
-        when(listRepository.findByUserId(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
+        when(listRepository.findByUserIdOrderByIsPinnedDesc(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
             .thenReturn(unknownWordLists);
 
         when(listRepository.findById(UUID.fromString("cc04e013-6d5e-4015-887f-5e5a9bc58382")))
@@ -198,7 +198,7 @@ class UnknownWordServiceTest {
             .isPinned(false)
             .imageUrl("imageUrl")
             .build());
-        when(listRepository.findByUserId(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
+        when(listRepository.findByUserIdOrderByIsPinnedDesc(UUID.fromString("67a444dc-14f4-4abc-bd83-b1c380f2004d")))
             .thenReturn(unknownWordLists);
 
         // Configure IUnknownWordListRepository.findById(...).


### PR DESCRIPTION
Word lists are now ordered by isPinned so that the pinned lists can be shown first on the app. 