### PR TITLE
fix(LINGUIST-369): Partial update for profile

### DIFF
--- a/src/main/java/app/linguistai/bmvp/enums/EnglishLevel.java
+++ b/src/main/java/app/linguistai/bmvp/enums/EnglishLevel.java
@@ -1,11 +1,21 @@
 package app.linguistai.bmvp.enums;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum EnglishLevel {
-    DONT_KNOW("Don't Know"),
-    BEGINNER("Beginner"),
-    INTERMEDIATE("Intermediate"),
-    ADVANCED("Advanced"),
-    NATIVE("Native");
+    DONT_KNOW("DONT_KNOW"),
+    BEGINNER("BEGINNER"),
+    INTERMEDIATE("INTERMEDIATE"),
+    ADVANCED("ADVANCED"),
+    NATIVE("NATIVE");
+
+    private static final Map<String, EnglishLevel> LEVEL_MAP = new HashMap<>();
+    static {
+        for (EnglishLevel level : EnglishLevel.values()) {
+            LEVEL_MAP.put(level.levelString, level);
+        }
+    }
 
     private final String levelString;
 
@@ -28,5 +38,9 @@ public enum EnglishLevel {
             }
         }
         return EnglishLevel.DONT_KNOW; // default if level not found
+    }
+
+    public static EnglishLevel fromStringOrDefault(String levelString) {
+        return LEVEL_MAP.getOrDefault(levelString, DONT_KNOW);
     }
 }

--- a/src/main/java/app/linguistai/bmvp/request/QUserProfile.java
+++ b/src/main/java/app/linguistai/bmvp/request/QUserProfile.java
@@ -2,23 +2,16 @@ package app.linguistai.bmvp.request;
 
 import java.time.LocalDate;
 import java.util.List;
-
-import app.linguistai.bmvp.enums.EnglishLevel;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class QUserProfile {
-    @NotBlank
+
     private String name;
 
-    @NotNull
     private LocalDate birthDate;
 
-    @NotNull
-    private EnglishLevel englishLevel;
+    private String englishLevel;
 
-    @NotNull
     private List<String> hobbies;
 }

--- a/src/main/java/app/linguistai/bmvp/service/AccountService.java
+++ b/src/main/java/app/linguistai/bmvp/service/AccountService.java
@@ -18,6 +18,7 @@ import app.linguistai.bmvp.repository.IResetTokenRepository;
 import app.linguistai.bmvp.service.currency.ITransactionService;
 import app.linguistai.bmvp.service.gamification.IXPService;
 import app.linguistai.bmvp.service.gamification.quest.IQuestService;
+import app.linguistai.bmvp.service.profile.ProfileService;
 import app.linguistai.bmvp.service.stats.UserLoggedDateService;
 import app.linguistai.bmvp.service.wordbank.UnknownWordService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +69,7 @@ public class AccountService {
     private final ITransactionService transactionService;
     private final IXPService xpService;
     private final IQuestService questService;
+    private final ProfileService profileService;
 
     public RLoginUser login(QUserLogin user) throws Exception {
         try {
@@ -212,6 +214,7 @@ public class AccountService {
             }
 
             xpService.createUserXPForRegister(newUser);
+            profileService.createEmptyProfile(newUser.getId());
             unknownWordService.addPredefinedWordList(DEFAULT_WORD_LIST_FILE, newUser.getEmail());
           
             // Create access and reset tokens so that user does not have to log in after registering

--- a/src/main/java/app/linguistai/bmvp/service/profile/ProfileService.java
+++ b/src/main/java/app/linguistai/bmvp/service/profile/ProfileService.java
@@ -112,7 +112,7 @@ public class ProfileService {
 
             // If ML service base URL is not set, return the profile without sending it to ML service
             if (ML_SERVICE_BASE_URL == null || ML_SERVICE_BASE_URL.isEmpty()) {
-                System.out.println("ML Service Base URL is not set!");
+                log.error("ML Service Base URL is not set!");
                 return userProfile;
             }
 
@@ -129,11 +129,11 @@ public class ProfileService {
                 .bodyToMono(String.class)
                 .subscribe(response -> {
                     if (response != null) {
-                        System.out.println("updateProfile - Response from ML service: " + response);
+                        log.info("updateProfile - Response from ML service: " + response);
                     }
                 }, error -> {
                     if (error != null) {
-                        System.out.println("updateProfile - Error from ML service: " + error.getMessage());
+                        log.error("updateProfile - Error from ML service: " + error.getMessage());
                     }
                 });
 


### PR DESCRIPTION
Normally, profile service's update method only allowed total updates, i.e. each field had to be updated.
This was a problem because during the onboarding process we allowed users to skip filling in certain fields. 

Now, we can do partial updates. A disadvantage is that if, for example, we want to set birthDate = "", then the birth date will not be affected. 

Additionally, empty user profiles are constructed upon registration. 
