### PR TITLE
feat(LINGUIST-453): Get quiz items and decrease by type endpoints

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/StoreConsts.java
+++ b/src/main/java/app/linguistai/bmvp/consts/StoreConsts.java
@@ -4,10 +4,11 @@ public class StoreConsts {
     // Types
     public static final String TYPE_DOUBLE_ANSWER = "Double Answer";
     public static final String TYPE_ELIMINATE_WRONG_ANSWER = "Eliminate Wrong Answer";
+    public static final String[] QUIZ_TYPES = {TYPE_DOUBLE_ANSWER, TYPE_ELIMINATE_WRONG_ANSWER};
 
     // Descriptions
     public static final String DESCRIPTION_DOUBLE_ANSWER = "Unlock the ability to answer a question twice for better practice.";
-    public static final String DESCRIPTION_ELIMINATE_WRONG_ANSWER = "Unlock the ability to eliminate one wrong answer choice during a quiz.";
+    public static final String DESCRIPTION_ELIMINATE_WRONG_ANSWER = "Unlock the ability to eliminate two wrong answers during a quiz.";
 
     // Prices
     public static final Long PRICE_DOUBLE_ANSWER = 100L;

--- a/src/main/java/app/linguistai/bmvp/controller/gamification/StoreController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/gamification/StoreController.java
@@ -1,5 +1,6 @@
 package app.linguistai.bmvp.controller.gamification;
 
+import app.linguistai.bmvp.response.gamification.store.RQuizItems;
 import app.linguistai.bmvp.response.gamification.store.RStoreItems;
 import app.linguistai.bmvp.response.gamification.store.RUserItem;
 import app.linguistai.bmvp.response.gamification.store.RUserItems;
@@ -53,6 +54,18 @@ public class StoreController {
         return Response.create("Successfully fetched all enabled store items", HttpStatus.OK, storeService.getAllEnabledStoreItems(page, size));
     }
 
+    @GetMapping("/quiz-items")
+    @Operation(summary = "Get all quiz related store/user items", description = "Retrieves all quiz related user items with quantities and gems. Includes enabled store items the user does not have, with quantity 0.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully fetched all quiz items", content =
+                    {@Content(mediaType = "application/json", array = @ArraySchema(schema =
+                    @Schema(implementation = RQuizItems.class)))}),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> getQuizItems(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) throws Exception {
+        return Response.create("Successfully fetched all quiz items", HttpStatus.OK, storeService.getAllQuizItems(email, page, size));
+    }
+
     @GetMapping("/user-items")
     @Operation(summary = "Get user items", description = "Retrieves a user's items and their quantity")
     @ApiResponses(value = {
@@ -80,7 +93,7 @@ public class StoreController {
     }
 
     @PostMapping("/user-items/decrease-quantity")
-    @Operation(summary = "Decrease user item quantity", description = "Decreases the quantity of a user item")
+    @Operation(summary = "Decrease user item quantity by store id", description = "Decreases the quantity of a user item by store item's id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User item quantity decreased successfully", content =
                     {@Content(mediaType = "application/json", schema =
@@ -90,5 +103,19 @@ public class StoreController {
     })
     public ResponseEntity<Object> decreaseUserItemQuantity(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam @NotBlank UUID itemId) throws Exception {
         return Response.create("User item quantity decreased successfully", HttpStatus.OK, storeService.decreaseUserItemQuantity(email, itemId));
+    }
+
+
+    @PostMapping("/user-items/decrease-quantity-by-type")
+    @Operation(summary = "Decrease user item quantity by type", description = "Decreases the quantity of a user item by store item's type")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User item quantity decreased successfully", content =
+                    {@Content(mediaType = "application/json", schema =
+                    @Schema(implementation = RUserItem.class))}),
+            @ApiResponse(responseCode = "404", description = "User, store item or the user item not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<Object> decreaseUserItemQuantityByType(@RequestHeader(Header.USER_EMAIL) String email, @RequestParam @NotBlank String type) throws Exception {
+        return Response.create("User item quantity decreased successfully", HttpStatus.OK, storeService.decreaseUserItemQuantity(email, type));
     }
 }

--- a/src/main/java/app/linguistai/bmvp/repository/gamification/store/IStoreItemRepository.java
+++ b/src/main/java/app/linguistai/bmvp/repository/gamification/store/IStoreItemRepository.java
@@ -13,4 +13,5 @@ import java.util.UUID;
 public interface IStoreItemRepository extends JpaRepository<StoreItem, UUID> {
     Page<StoreItem> findByEnabled(boolean enabled, Pageable pageable);
     Optional<StoreItem> findByType(String type);
+    Page<StoreItem> findByTypeIn(String[] types, Pageable pageable);
 }

--- a/src/main/java/app/linguistai/bmvp/response/gamification/store/RQuizItems.java
+++ b/src/main/java/app/linguistai/bmvp/response/gamification/store/RQuizItems.java
@@ -1,0 +1,18 @@
+package app.linguistai.bmvp.response.gamification.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class RQuizItems {
+    private List<RUserItem> quizItems;
+    private int totalPages;
+    private int currentPage;
+    private int pageSize;
+    private Long gems;
+}


### PR DESCRIPTION
Added: 

- Quiz items endpoint: returns all the quiz items (currently, double answer and eliminate answer items) and the quantity the user owns. Additionally, it returns the user's gems so they can be shown on the mcq page. 
- Decrease by type endpoint: Decreases a user's item by user email and the item's type as a string (rather than its id). In hindsight, this might not have been necessary as we already have an id-based decrease endpoint, but it works the same since types must be unique for store items. 